### PR TITLE
Improving way to handle graphql queries with a new handleItemsList function

### DIFF
--- a/src/actions/ProductsActions.ts
+++ b/src/actions/ProductsActions.ts
@@ -28,11 +28,11 @@ export const getListOfProducts = ({
     order_by_name: null,
   },
 }: getListOfProductsTypes) => {
-  query = `%${query}%`;
+  const name = `%${query}%`;
 
   return new Promise<getListOfProductsReturnTypes>((resolve, reject) => {
     const variables = {
-      name: query,
+      name,
       offset,
       limit,
       ...order_by,

--- a/src/actions/ProductsActions.ts
+++ b/src/actions/ProductsActions.ts
@@ -1,43 +1,13 @@
 import { Notify } from 'quasar';
 import { getListOfProductsQuery } from '../services';
-import { useQuery } from '../utils/apollo';
+import {
+  useQuery,
+  actionCallbackReturnTypes,
+  actionCallbackParamsTypes,
+} from '../utils/apollo';
 
-interface getListOfProductsReturnTypes {
-  products: object[];
-  totalProducts: number;
-}
-
-interface getListOfProductsTypes {
-  limit: number;
-  offset: number;
-  query: string;
-  order_by: getListOfProductsOrderByTypes;
-}
-
-interface getListOfProductsOrderByTypes {
-  order_by_price?: any;
-  order_by_name?: any;
-}
-
-export const getListOfProducts = ({
-  limit = 10,
-  offset = 0,
-  query = '',
-  order_by = {
-    order_by_price: null,
-    order_by_name: null,
-  },
-}: getListOfProductsTypes) => {
-  const name = `%${query}%`;
-
-  return new Promise<getListOfProductsReturnTypes>((resolve, reject) => {
-    const variables = {
-      name,
-      offset,
-      limit,
-      ...order_by,
-    };
-
+export const getListOfProducts = (variables: actionCallbackParamsTypes) => {
+  return new Promise<actionCallbackReturnTypes>((resolve, reject) => {
     useQuery(getListOfProductsQuery, variables)
       .then(({ providers }) => {
         if (!providers || !providers[0] || !providers[0].products) {
@@ -51,8 +21,8 @@ export const getListOfProducts = ({
         }
 
         resolve({
-          products: providers[0].products,
-          totalProducts: providers[0].products_aggregate.aggregate.count,
+          items: providers[0].products,
+          totalItems: providers[0].products_aggregate.aggregate.count,
         });
       })
       .catch((err) => {

--- a/src/pages/Products/Products.layout.vue
+++ b/src/pages/Products/Products.layout.vue
@@ -12,8 +12,8 @@
         :model-value="sortSelectValue"
         @update:model-value="$emit('onSortList', $event)"
         :options="sortSelectOptions"
-        option-label="name"
-        option-value="id"
+        option-label="label"
+        option-value="label"
         stack-label
         label="Single selection"
       />

--- a/src/pages/Products/index.vue
+++ b/src/pages/Products/index.vue
@@ -25,27 +25,27 @@ import './Products.scss';
 const options = ref([
   {
     label: 'No ordenar',
-    value: null,
+    content: null,
     name: 'none_filter',
   },
   {
     label: 'Menor precio primero',
-    value: 'asc',
+    content: 'asc',
     name: 'order_by_price',
   },
   {
     label: 'Mayor precio primero',
-    value: 'desc',
+    content: 'desc',
     name: 'order_by_price',
   },
   {
     label: 'Ordenar alfabeticamente A-Z',
-    value: 'asc',
+    content: 'asc',
     name: 'order_by_name',
   },
   {
     label: 'Ordenar alfabeticamente Z-A',
-    value: 'desc',
+    content: 'desc',
     name: 'order_by_name',
   },
 ]);

--- a/src/pages/Products/index.vue
+++ b/src/pages/Products/index.vue
@@ -18,128 +18,35 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue';
 import { getListOfProducts } from '../../actions/ProductsActions';
-import { getTotalPages, getOffset } from '../../utils/pagination';
+import { handleListQuery } from '../../utils/apollo';
 import ProductsLayout from './Products.layout.vue';
 import './Products.scss';
 
-const handleProductList = () => {
-  const products = ref<object[]>([]);
-  const limit = ref<number>(10);
-  const query = ref<string>('');
-  const totalProducts = ref<number>(0);
-  const totalPages = ref<number>(1);
-  const currentPage = ref<number>(1);
-  const isLoading = ref<boolean>(false);
-  const searchText = ref<string>('');
-  const order_by = ref<string>('');
-
-  const getOrderByGraphQLVariables = (order_by: any): object => {
-    const order_by_query = <any>{
-      order_by_price: null,
-      order_by_name: null,
-    };
-
-    switch (order_by.id) {
-      case 'order_by_price_asc':
-        order_by_query.order_by_price = 'asc';
-        break;
-      case 'order_by_price_desc':
-        order_by_query.order_by_price = 'desc';
-        break;
-      case 'order_by_name_asc':
-        order_by_query.order_by_name = 'asc';
-        break;
-      case 'order_by_name_desc':
-        order_by_query.order_by_name = 'desc';
-        break;
-    }
-
-    return order_by_query;
-  };
-
-  const getProductList = (
-    _currentPage: number,
-    _query: string,
-    _order_by: string
-  ) => {
-    isLoading.value = true;
-    currentPage.value = _currentPage;
-    query.value = _query;
-    order_by.value = _order_by;
-
-    const offset = getOffset({
-      currentPage: currentPage.value,
-      limit: limit.value,
-    });
-
-    const variables = {
-      offset,
-      limit: limit.value,
-      query: query.value,
-      order_by: getOrderByGraphQLVariables(order_by.value),
-    };
-
-    getListOfProducts(variables)
-      .then((result) => {
-        products.value = result.products;
-
-        totalProducts.value = result.totalProducts;
-
-        totalPages.value = getTotalPages({
-          totalItems: totalProducts.value,
-          limit: limit.value,
-        });
-
-        isLoading.value = false;
-      })
-      .finally(() => {
-        isLoading.value = false;
-      });
-  };
-
-  const onClearSearch = () => {
-    searchText.value = '';
-
-    if (query.value) {
-      getProductList(1, '', order_by.value);
-    }
-  };
-
-  return {
-    products,
-    limit,
-    query,
-    totalProducts,
-    totalPages,
-    currentPage,
-    isLoading,
-    searchText,
-    order_by,
-    onClearSearch,
-    getProductList,
-  };
-};
-
 const options = ref([
   {
-    name: 'No ordenar',
-    id: 'none_filter',
+    label: 'No ordenar',
+    value: null,
+    name: 'none_filter',
   },
   {
-    name: 'Menor precio primero',
-    id: 'order_by_price_asc',
+    label: 'Menor precio primero',
+    value: 'asc',
+    name: 'order_by_price',
   },
   {
-    name: 'Mayor precio primero',
-    id: 'order_by_price_desc',
+    label: 'Mayor precio primero',
+    value: 'desc',
+    name: 'order_by_price',
   },
   {
-    name: 'Ordenar alfabeticamente A-Z',
-    id: 'order_by_name_asc',
+    label: 'Ordenar alfabeticamente A-Z',
+    value: 'asc',
+    name: 'order_by_name',
   },
   {
-    name: 'Ordenar alfabeticamente Z-A',
-    id: 'order_by_name_desc',
+    label: 'Ordenar alfabeticamente Z-A',
+    value: 'desc',
+    name: 'order_by_name',
   },
 ]);
 
@@ -150,18 +57,18 @@ export default defineComponent({
   },
   setup() {
     const {
-      products,
+      items: products,
       limit,
       query,
-      totalProducts,
+      totalItems: totalProducts,
       totalPages,
       currentPage,
       isLoading,
       searchText,
       order_by,
       onClearSearch,
-      getProductList,
-    } = handleProductList();
+      getItemsList: getProductList,
+    } = handleListQuery(getListOfProducts);
 
     getProductList(currentPage.value, query.value, order_by.value);
 

--- a/src/services/queries/Products.js
+++ b/src/services/queries/Products.js
@@ -4,7 +4,7 @@ export const getListOfProductsQuery = gql`
   query getListOfProducts(
     $name: String = "%%"
     $limit: Int = 10
-    $offset: Int = 10
+    $offset: Int = 0
     $order_by_price: order_by = null
     $order_by_name: order_by = null
   ) {

--- a/src/services/queries/Products.js
+++ b/src/services/queries/Products.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const getListOfProductsQuery = gql`
   query getListOfProducts(
-    $name: String = "%%"
+    $query: String = "%%"
     $limit: Int = 10
     $offset: Int = 0
     $order_by_price: order_by = null
@@ -12,12 +12,12 @@ export const getListOfProductsQuery = gql`
       products(
         where: {
           _or: [
-            { name: { _ilike: $name } }
-            { description: { _ilike: $name } }
+            { name: { _ilike: $query } }
+            { description: { _ilike: $query } }
             {
               provider: {
-                commercial_name: { _ilike: $name }
-                legal_name: { _ilike: $name }
+                commercial_name: { _ilike: $query }
+                legal_name: { _ilike: $query }
               }
             }
           ]
@@ -41,12 +41,12 @@ export const getListOfProductsQuery = gql`
       products_aggregate(
         where: {
           _or: [
-            { name: { _ilike: $name } }
-            { description: { _ilike: $name } }
+            { name: { _ilike: $query } }
+            { description: { _ilike: $query } }
             {
               provider: {
-                commercial_name: { _ilike: $name }
-                legal_name: { _ilike: $name }
+                commercial_name: { _ilike: $query }
+                legal_name: { _ilike: $query }
               }
             }
           ]

--- a/src/utils/apollo.ts
+++ b/src/utils/apollo.ts
@@ -13,6 +13,8 @@ import {
 import { DocumentNode } from 'graphql';
 
 import { Notify } from 'quasar';
+import { ref } from 'vue';
+import { getOffset, getTotalPages } from './pagination';
 
 const httpLink = createHttpLink({
   // You should use an absolute URL here
@@ -32,6 +34,7 @@ provideApolloClient(apolloClient);
 export interface queryResult {
   users?: any;
   providers?: any;
+  providers_aggregate?: any;
 }
 
 export const useQuery = (query: DocumentNode, variables: object = {}) => {
@@ -52,4 +55,120 @@ export const useQuery = (query: DocumentNode, variables: object = {}) => {
       resolve(data);
     });
   });
+};
+
+export interface actionCallbackReturnTypes {
+  items: object[];
+  totalItems: number;
+}
+
+export interface orderByGraphQLVariablesTypes {
+  label?: string;
+  value?: string;
+  name?: string;
+}
+
+export interface actionCallbackParamsTypes {
+  limit: number;
+  offset: number;
+  query: string;
+  order_by?: orderByGraphQLVariablesTypes;
+}
+
+export type actionCallback =
+  ({}: actionCallbackParamsTypes) => Promise<actionCallbackReturnTypes>;
+
+export const handleListQuery = (actionCallback: actionCallback) => {
+  // Editable states
+  const searchText = ref<string>('');
+
+  // States
+  const isLoading = ref<boolean>(false);
+  const currentPage = ref<number>(1);
+
+  // Filters
+  const order_by = ref<orderByGraphQLVariablesTypes>({
+    label: '',
+    value: '',
+    name: '',
+  });
+  const limit = ref<number>(10);
+  const query = ref<string>('');
+
+  // Results
+  const totalPages = ref<number>(1);
+  const totalItems = ref<number>(0);
+  const items = ref<object[]>([]);
+
+  const getOrderByGraphQLVariables = (
+    order_by: orderByGraphQLVariablesTypes
+  ) => {
+    if (!order_by.label || !order_by.value || !order_by.name) return {};
+
+    return { [order_by.label]: order_by.value };
+  };
+
+  const getItemsList = (
+    _currentPage: number,
+    _query: string,
+    _order_by: orderByGraphQLVariablesTypes
+  ) => {
+    isLoading.value = true;
+    currentPage.value = _currentPage;
+    query.value = _query;
+    order_by.value = _order_by;
+
+    const offset = getOffset({
+      currentPage: currentPage.value,
+      limit: limit.value,
+    });
+
+    const variables = {
+      offset,
+      limit: limit.value,
+      query: `%${query.value}%`,
+      ...(order_by.value && {
+        order_by: getOrderByGraphQLVariables(order_by.value),
+      }),
+    };
+
+    actionCallback(variables)
+      .then((result) => {
+        items.value = result.items;
+
+        totalItems.value = result.totalItems;
+
+        totalPages.value = getTotalPages({
+          totalItems: totalItems.value,
+          limit: limit.value,
+        });
+
+        isLoading.value = false;
+      })
+      .finally(() => {
+        isLoading.value = false;
+      });
+  };
+
+  const onClearSearch = () => {
+    searchText.value = '';
+
+    if (query.value) {
+      getItemsList(1, '', order_by.value);
+    }
+  };
+
+  return {
+    items,
+    limit,
+    query,
+    totalItems,
+    totalPages,
+    currentPage,
+    isLoading,
+    searchText,
+    order_by,
+    onClearSearch,
+    getItemsList,
+  };
 };

--- a/src/utils/apollo.ts
+++ b/src/utils/apollo.ts
@@ -103,9 +103,9 @@ export const handleListQuery = (actionCallback: actionCallback) => {
   const getOrderByGraphQLVariables = (
     order_by: orderByGraphQLVariablesTypes
   ) => {
-    if (!order_by.label || !order_by.value || !order_by.name) return {};
+    if (!order_by.value || !order_by.name) return {};
 
-    return { [order_by.label]: order_by.value };
+    return { [order_by.name]: order_by.value };
   };
 
   const getItemsList = (
@@ -127,9 +127,7 @@ export const handleListQuery = (actionCallback: actionCallback) => {
       offset,
       limit: limit.value,
       query: `%${query.value}%`,
-      ...(order_by.value && {
-        order_by: getOrderByGraphQLVariables(order_by.value),
-      }),
+      ...(order_by.value && getOrderByGraphQLVariables(order_by.value)),
     };
 
     actionCallback(variables)

--- a/src/utils/apollo.ts
+++ b/src/utils/apollo.ts
@@ -64,7 +64,7 @@ export interface actionCallbackReturnTypes {
 
 export interface orderByGraphQLVariablesTypes {
   label?: string;
-  value?: string;
+  content?: string;
   name?: string;
 }
 
@@ -89,8 +89,8 @@ export const handleListQuery = (actionCallback: actionCallback) => {
   // Filters
   const order_by = ref<orderByGraphQLVariablesTypes>({
     label: '',
-    value: '',
     name: '',
+    content: '',
   });
   const limit = ref<number>(10);
   const query = ref<string>('');
@@ -103,9 +103,9 @@ export const handleListQuery = (actionCallback: actionCallback) => {
   const getOrderByGraphQLVariables = (
     order_by: orderByGraphQLVariablesTypes
   ) => {
-    if (!order_by.value || !order_by.name) return {};
+    if (!order_by.content || !order_by.name) return {};
 
-    return { [order_by.name]: order_by.value };
+    return { [order_by.name]: order_by.content };
   };
 
   const getItemsList = (
@@ -127,7 +127,8 @@ export const handleListQuery = (actionCallback: actionCallback) => {
       offset,
       limit: limit.value,
       query: `%${query.value}%`,
-      ...(order_by.value && getOrderByGraphQLVariables(order_by.value)),
+      ...(order_by.value?.content &&
+        getOrderByGraphQLVariables(order_by.value)),
     };
 
     actionCallback(variables)


### PR DESCRIPTION
I'm trying to improve the code, doing more reusable the "handleProductList" function, changing her name for "handleItemsList" that is creating and returning all that a view with a list needs:

```javascript
// States
items // It's the result of the query
limit // It's the limit of items for query
query // This param is filtering the items for a string
totalItems // It's the total of items that we've got on the query, perfect for the pagination
totalPages // It's the total of pages that we can do with the actual limit and the total of items that we've got from the query
currentPage // It's the actual page where we were
isLoading // It's the actual state of the query 
searchText // Please use this variable to save that the user have wrote on the search bar
order_by // You can use this if you want that your list was ordered by some params

// Functions
onClearSearch() // Call this function to clear the search 
getItemsList(currentPage, query, order_by) // Call this function to get the updated list of items with the new params that you've include in
```

You can use this states on your code how you need, for example add the `currentPage` and `totalPages` returned to the paginator, use the `items` to show the return on your page, and add the `order_by` variable to the input where the user select the order_by preferred.

I've made this since when I've started to wrote Providers view, I've noticed that the logic to get items of a list with pagination, etc, is repeated, and I want to avoid repeat that logic each time I want get the items of a list.

Then I've made this **util** and I've created a Demo of how would look the Providers view using this function, you can see that code here: #11  

Please let me know what do you think, if you know a way to improve it.