### PR TITLE
Adding config for PreviewJs file

### DIFF
--- a/preview.config.js
+++ b/preview.config.js
@@ -1,0 +1,11 @@
+const { quasar } = require('@quasar/vite-plugin');
+
+module.exports = {
+  vite: {
+    plugins: [quasar()],
+  },
+  wrapper: {
+    path: 'src/__previewjs__/PreviewWrapper.vue',
+    componentName: 'default',
+  },
+};

--- a/src/__previewjs__/PreviewWrapper.vue
+++ b/src/__previewjs__/PreviewWrapper.vue
@@ -6,7 +6,6 @@
 
 <script>
 import { defineComponent, getCurrentInstance } from '@vue/runtime-core';
-import 'node_modules/quasar/src/css/index.sass';
 import { Quasar } from 'quasar';
 
 export default defineComponent({
@@ -17,10 +16,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss">
-@import '../css/quasar.variables.scss';
-@import '../css/app.scss';
+@import '../../node_modules/quasar/src/css/index.sass';
 @import '../../node_modules/@quasar/extras/material-icons/material-icons.css';
-@import '../../node_modules/@quasar/extras/material-icons-outlined/material-outlined.css';
-@import '../../node_modules/@quasar/extras/material-icons-round/material-round.css';
-@import '../../node_modules/@quasar/extras/material-icons-sharp/material-sharp.css';
+@import '../../node_modules/@quasar/extras/material-icons-outlined/material-icons-outlined.css';
+@import '../../node_modules/@quasar/extras/material-icons-round/material-icons-round.css';
+@import '../../node_modules/@quasar/extras/material-icons-sharp/material-icons-sharp.css';
 </style>

--- a/src/__previewjs__/PreviewWrapper.vue
+++ b/src/__previewjs__/PreviewWrapper.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="wrapped">
+    <slot />
+  </div>
+</template>
+
+<script>
+import { defineComponent, getCurrentInstance } from '@vue/runtime-core';
+import 'node_modules/quasar/src/css/index.sass';
+import { Quasar } from 'quasar';
+
+export default defineComponent({
+  setup() {
+    getCurrentInstance().appContext.app.use(Quasar);
+  },
+});
+</script>
+
+<style lang="scss">
+@import '../css/quasar.variables.scss';
+@import '../css/app.scss';
+@import '../../node_modules/@quasar/extras/material-icons/material-icons.css';
+@import '../../node_modules/@quasar/extras/material-icons-outlined/material-outlined.css';
+@import '../../node_modules/@quasar/extras/material-icons-round/material-round.css';
+@import '../../node_modules/@quasar/extras/material-icons-sharp/material-sharp.css';
+</style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,5 +1,23 @@
 // app global css in SCSS form
 
+// variables
+$white-flight: #f2f2f2;
+$gray-dim: #707070;
+$gray-chinese-silver: #ccc7c7;
+$lightgray: #c9c9c9;
+
+.bg-white-flight {
+  background-color: $white-flight;
+}
+
+.text-white-flight {
+  color: $white-flight;
+}
+
+.text-gray-dim {
+  color: $gray-dim;
+}
+
 img {
   max-width: 100%;
 }

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -22,22 +22,3 @@ $positive: #21ba45;
 $negative: #c10015;
 $info: #31ccec;
 $warning: #f2c037;
-
-// Custom colors
-$white-flight: #f2f2f2;
-$gray-dim: #707070;
-$gray-chinese-silver: #ccc7c7;
-
-.bg-white-flight {
-  background-color: $white-flight;
-}
-
-.text-white-flight {
-  color: $white-flight;
-}
-
-.text-gray-dim {
-  color: $gray-dim;
-}
-
-$lightgray: #c9c9c9;

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -22,3 +22,25 @@ $positive: #21ba45;
 $negative: #c10015;
 $info: #31ccec;
 $warning: #f2c037;
+
+// variables
+$white-flight: #f2f2f2;
+$gray-dim: #707070;
+$gray-chinese-silver: #ccc7c7;
+$lightgray: #c9c9c9;
+
+.bg-white-flight {
+  background-color: $white-flight;
+}
+
+.text-white-flight {
+  color: $white-flight;
+}
+
+.text-gray-dim {
+  color: $gray-dim;
+}
+
+img {
+  max-width: 100%;
+}

--- a/src/pages/Login/Login.layout.vue
+++ b/src/pages/Login/Login.layout.vue
@@ -67,6 +67,7 @@
 <script>
 import { defineComponent } from 'vue';
 import didLogo from '../../assets/logos/didperu.svg';
+import './Login.scss';
 
 export default defineComponent({
   props: {

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -1,3 +1,6 @@
+@import '../../css/quasar.variables.scss';
+@import '../../css/app.scss';
+
 .login {
   padding: 2.5rem 1.25rem 0;
   max-width: 64rem;


### PR DESCRIPTION
## Explanation

I'm testing this extension for VSCode, to allow configuration on the project if needed. I've tested it and I have noticed that QuasarJS component was given me an error.

I have solved it with help on this discussion https://github.com/fwouts/previewjs/discussions/654, then I have found problems with how to import the icons and the CSS, I have created a wrapper file and imported the CSS here.

Then I found problems with how to import the SCSS variables, since importing it on the `<style></style>` on the wrapper wasn't enough. I haven't found a way to import variables globally and see them correctly on previewjs.

The just way that I have found is to import the SCSS variables on each file.

## Example

I have made the example with a login view

![image](https://user-images.githubusercontent.com/66505715/172508584-d663d782-2819-4698-ab33-e40f6f03a2ca.png)

I just have to import the SCSS variables on the top of the SCSS file.

## How to test

1. Install the extension: https://marketplace.visualstudio.com/items?itemName=zenclabs.previewjs
2. Go to any file that you want test (don't work with files that made calls to the database, just with agnostic components)
3. Tab `F1` and search PreviewJs 
![image](https://user-images.githubusercontent.com/66505715/172508718-35c9001e-9fca-4d93-b892-f93cf597aa19.png)
4. Run it
5. You should see the preview

If you have doubts about this, I can meet with you and see how to ran the PreviewJS