### PR TITLE
Added media query to small screens

### DIFF
--- a/src/pages/Providers/Providers.scss
+++ b/src/pages/Providers/Providers.scss
@@ -1,6 +1,6 @@
 .Providers {
   &__content {
-    padding: 2rem 1.5625rem;
+    padding: 2rem 1.56rem;
   }
 
   &__header {

--- a/src/pages/Providers/Providers.scss
+++ b/src/pages/Providers/Providers.scss
@@ -4,7 +4,7 @@
   }
 
   &__header {
-    padding-left: 3.94rem;
+    padding-left: 1.98rem;
   }
 
   &__no-providers-text {
@@ -15,6 +15,10 @@
   @media screen and (min-width: 414px) {
     &__content {
       padding: 2rem 3.125rem;
+    }
+
+    &__header {
+      padding-left: 3.94rem;
     }
   }
 }

--- a/src/pages/Providers/Providers.scss
+++ b/src/pages/Providers/Providers.scss
@@ -1,6 +1,6 @@
 .Providers {
   &__content {
-    padding: 2rem 3.125rem;
+    padding: 2rem 1.5625rem;
   }
 
   &__header {
@@ -10,6 +10,12 @@
   &__no-providers-text {
     font-size: 1.2rem;
     text-align: center;
+  }
+
+  @media screen and (min-width: 414px) {
+    &__content {
+      padding: 2rem 3.125rem;
+    }
   }
 }
 
@@ -22,13 +28,16 @@
     cursor: pointer;
     height: 100%;
     width: 100%;
-    min-width: 6.25rem;
-    min-height: 6.25rem;
     aspect-ratio: 1/1;
 
     img {
       aspect-ratio: 1/1;
       object-fit: scale-down;
+    }
+
+    @media screen and (min-width: 414px) {
+      min-width: 6.25rem;
+      min-height: 6.25rem;
     }
   }
 


### PR DESCRIPTION
Fixed the issue https://github.com/Azordev/did-app/issues/101 which was caused by the large-padding in small screens.

Although this padding is part of the original design, in small screens can't be used, so I added a media query to avoid problems with small phones

![imagen](https://user-images.githubusercontent.com/66505715/192050867-38cdfe58-333a-40ea-a585-880376fa49bd.png)
