### PR TITLE
Create modal to change image profile

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,5 +19,7 @@ html,
 body,
 #q-app {
   height: 100%;
+  position: relative;
+  min-height: 650px;
 }
 </style>

--- a/src/components/ModalFile/ModalFile.vue
+++ b/src/components/ModalFile/ModalFile.vue
@@ -5,18 +5,19 @@
         <q-card-section class="row justify-end q-pb-none">
           <q-btn icon="close" flat round dense v-close-popup />
         </q-card-section>
-        <q-card-section class="column items-center text-center q-pt-none gap-sm"
-          >El tamaño ideal para las imágenes de avatar es de
-          <b>100x100 píxeles</b>. Te sugerimos ajustar tu imagen antes de
-          subirla
-          <q-space />
+        <q-card-section class="text-center q-pt-none">
+          <div class="q-mb-sm">
+            El tamaño ideal para las imágenes de avatar es de
+            <b>100x100 píxeles</b>.
+          </div>
+          Te sugerimos ajustar tu imagen antes de subirla
           <q-file
             label-color="white"
             bg-color="dark"
             standout
             v-model="selectedFiles"
             label="Subir imagen"
-            class="q-mt-md"
+            class="q-mt-md custom"
             accept="image/png, image/jpeg, image/jpg"
             @input="handleChange"
           >
@@ -31,6 +32,7 @@
 </template>
 <script>
 import { useDialogPluginComponent } from 'quasar';
+import './styles.scss';
 
 export default {
   props: {

--- a/src/components/ModalFile/ModalFile.vue
+++ b/src/components/ModalFile/ModalFile.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="q-pa-md q-gutter-sm">
+    <q-dialog ref="dialogRef">
+      <q-card>
+        <q-card-section class="row justify-end q-pb-none">
+          <q-btn icon="close" flat round dense v-close-popup />
+        </q-card-section>
+        <q-card-section class="column items-center text-center q-pt-none gap-sm"
+          >El tamaño ideal para las imágenes de avatar es de
+          <b>100x100 píxeles</b>. Te sugerimos ajustar tu imagen antes de
+          subirla
+          <q-space />
+          <q-file
+            label-color="white"
+            bg-color="dark"
+            standout
+            v-model="selectedFiles"
+            label="Subir imagen"
+            class="q-mt-md"
+            accept="image/png, image/jpeg, image/jpg"
+            @input="handleChange"
+          >
+            <template v-slot:append>
+              <q-icon name="upload" color="white" />
+            </template>
+          </q-file>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+<script>
+import { useDialogPluginComponent } from 'quasar';
+
+export default {
+  props: {
+    id: {
+      type: String,
+      required: true,
+    },
+    uploadImage: {
+      type: Function,
+    },
+  },
+  emits: [...useDialogPluginComponent.emits],
+  methods: {
+    async handleChange(event) {
+      await this.uploadImage(event);
+      this.dialogRef.hide();
+    },
+  },
+  setup() {
+    const { dialogRef } = useDialogPluginComponent();
+    return {
+      dialogRef,
+    };
+  },
+};
+</script>

--- a/src/components/ModalFile/index.js
+++ b/src/components/ModalFile/index.js
@@ -1,0 +1,3 @@
+import ModalFile from './ModalFile.vue';
+
+export default ModalFile;

--- a/src/components/ModalFile/styles.scss
+++ b/src/components/ModalFile/styles.scss
@@ -1,0 +1,14 @@
+.custom {
+  .q-field__inner {
+    max-width: 180px;
+    margin: 0 auto;
+  }
+
+  .q-field__control {
+    padding: 0 25px;
+  }
+
+  .q-field__append {
+    padding-left: 8px;
+  }
+}

--- a/src/pages/Event/Event.layout.vue
+++ b/src/pages/Event/Event.layout.vue
@@ -16,6 +16,17 @@
         <div class="Event__description">
           {{ event.description }}
         </div>
+        <div class="q-mt-md">
+          <q-btn
+            v-if="event.requirements_url"
+            icon="cloud_download"
+            round
+            color="dark"
+            size="lg"
+            :href="event.requirements_url"
+            download
+          />
+        </div>
         <q-btn
           v-if="!userInscriptionId"
           @click="$emit('subscribeUserToEvent')"

--- a/src/pages/User/components/UserHeader/UserHeader.vue
+++ b/src/pages/User/components/UserHeader/UserHeader.vue
@@ -11,6 +11,7 @@
               class="UserHeader__avatar"
               color="black"
               text-color="white"
+              @click="openModal"
             >
               <q-img :src="showAvatar" />
               <q-icon
@@ -18,12 +19,6 @@
                 size="1.19rem"
                 class="UserHeader__editIcon"
                 name="add"
-              />
-              <input
-                type="file"
-                id="avatar"
-                accept="image/png, image/jpeg, image/jpg"
-                @change="uploadImage"
               />
             </q-avatar>
           </q-btn>
@@ -64,6 +59,8 @@ import {
   updateImageGraqhql,
 } from './utils/handleAvatarUpload';
 import { ref, Ref } from 'vue';
+import { Dialog } from 'quasar';
+import ModalFile from 'src/components/ModalFile/ModalFile.vue';
 
 export interface UserHeaderProps {
   isMembershipActive: boolean;
@@ -84,5 +81,15 @@ const uploadImage = async (event: Event) => {
   const { onUpdateUserAvatar } = updateImageGraqhql();
   onUpdateUserAvatar(props.id, uploadedImage);
   showAvatar.value = uploadedImage;
+};
+
+const openModal = async () => {
+  Dialog.create({
+    component: ModalFile,
+    componentProps: {
+      uploadImage: uploadImage,
+      id: props.id,
+    },
+  });
 };
 </script>

--- a/src/services/fragments/Event.js
+++ b/src/services/fragments/Event.js
@@ -6,6 +6,7 @@ export const EventInfo = gql`
     description
     image_url
     invitation_url
+    requirements_url
     title
     type
     id

--- a/src/utils/apollo.types.ts
+++ b/src/utils/apollo.types.ts
@@ -151,6 +151,7 @@ export interface Event {
   date: string;
   type: EventType.PRIVATE | EventType.PUBLIC;
   inscriptions?: Inscriptions[];
+  requirements_url?: string;
 }
 
 // Query returns


### PR DESCRIPTION
fix #134 

https://deploy-preview-135--did-app.netlify.app/

# Cambio: Modal de subida de imagen de perfil

Se ha realizado un cambio en la funcionalidad de la imagen de perfil, específicamente en la creación de un modal que se despliega al hacer clic en la imagen de perfil existente. El objetivo de este cambio es permitir a los usuarios subir una nueva imagen de perfil de manera más intuitiva.

## Descripción

El nuevo modal de subida de imagen de perfil proporciona una experiencia mejorada al usuario al interactuar con su imagen de perfil. Al hacer clic en la imagen de perfil actual, se abrirá un modal que contiene recomendaciones y un campo de carga de archivos estilizado.

Dentro del modal, se incluye un texto descriptivo que proporciona recomendaciones al usuario sobre el tamaño ideal de la imagen de perfil. En este caso, se sugiere que la imagen tenga un tamaño de 100x100 píxeles para una mejor visualización.

El campo de carga de archivos, que se presenta como un botón de "Subir imagen", permite al usuario seleccionar una imagen desde su dispositivo y subirla. Una vez que se ha seleccionado la imagen y se ha completado el proceso de carga, el modal se cerrará automáticamente.

Este cambio tiene como objetivo mejorar la experiencia del usuario al actualizar su imagen de perfil, brindando indicaciones claras y una interfaz fácil de usar.

## Beneficios

- Interfaz intuitiva: El uso de un modal proporciona una forma clara y directa para que los usuarios suban una nueva imagen de perfil.
- Recomendaciones claras: El texto descriptivo dentro del modal ofrece recomendaciones sobre el tamaño ideal de la imagen de perfil, lo que ayuda a los usuarios a ajustar su imagen antes de subirla.
- Cierre automático: Una vez que se ha completado la carga de la imagen, el modal se cierra automáticamente, lo que proporciona una transición fluida y evita que el modal permanezca abierto innecesariamente.